### PR TITLE
DROOLS-1701 Improved memory usage by EvaluationContextImpl

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
@@ -22,7 +22,9 @@ import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.util.EvalHelper;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
@@ -31,12 +33,12 @@ import java.util.function.Supplier;
 public class EvaluationContextImpl implements EvaluationContext {
 
     private final FEELEventListenersManager eventsManager;
-    private       Stack<ExecutionFrame> stack;
+    private ArrayDeque<ExecutionFrame> stack;
     private DMNRuntime dmnRuntime;
 
     public EvaluationContextImpl(FEELEventListenersManager eventsManager) {
         this.eventsManager = eventsManager;
-        this.stack = new Stack<>();
+        this.stack = new ArrayDeque<>();
         // we create a rootFrame to hold all the built in functions
         push( RootExecutionFrame.INSTANCE );
         // and then create a global frame to be the starting frame
@@ -62,7 +64,7 @@ public class EvaluationContextImpl implements EvaluationContext {
         return stack.peek();
     }
 
-    public Stack<ExecutionFrame> getStack() {
+    public Deque<ExecutionFrame> getStack() {
         return this.stack;
     }
 
@@ -136,8 +138,8 @@ public class EvaluationContextImpl implements EvaluationContext {
     @Override
     public Map<String, Object> getAllValues() {
         Map<String, Object> values = new HashMap<>(  );
-        for( int i = 0; i < stack.size(); i++ ) {
-            values.putAll( stack.get( i ).getAllValues() );
+        for (ExecutionFrame frame : stack) {
+            values.putAll( frame.getAllValues() );
         }
         return values;
     }


### PR DESCRIPTION
Currently java.util.Stack is used in EvaluationContextImpl to represent call stack. This data structure is highly inefficient since it copies arrays on every mutating operation. ArrayDeque offers better performance and less GC pressure while maintaining compact array-based internal structure.