### PR TITLE
DROOLS-1701 fixes to `between` and `in` (esp. with `null` handling)

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
@@ -67,6 +67,27 @@ public class CompiledFEELSemanticMappings {
                 highBoundary);
     }
 
+    public static Boolean includes(
+            EvaluationContext ctx,
+            Object range,
+            Object param) {
+        if (range instanceof Range) {
+            return ((Range) range).includes(param);
+        } else if (range instanceof List) {
+            return ((List) range).contains(param);
+        } else if (range == null){
+            ctx.notifyEvt( () -> new ASTEventBase(
+                    FEELEvent.Severity.ERROR,
+                    Msg.createMessage(
+                            Msg.IS_NULL,
+                            "range"),
+                    null));
+            return null;
+        } else {
+            return list(range).contains(param);
+        }
+    }
+
     private static boolean compatible(Comparable left, Comparable right) {
         Class<?> leftClass = left.getClass();
         Class<?> rightClass = right.getClass();
@@ -220,18 +241,23 @@ public class CompiledFEELSemanticMappings {
         return EvalHelper.isEqual(left, right, null);
     }
 
-    public static Boolean between(Object val, Object s, Object e) {
-        if (!val.getClass().isAssignableFrom(s.getClass())) {
-            // TODO here in the original code "interpreted" there was an error reporting utility.
+    public static Boolean between(EvaluationContext ctx,
+                                  Object value, Object start, Object end) {
+        if ( value == null ) { ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "value"), null) ); return null; }
+        if ( start == null ) { ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "start"), null) ); return null; }
+        if ( end == null )   { ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "end"), null) ); return null; }
+
+        if (!value.getClass().isAssignableFrom(start.getClass())) {
+            ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.X_TYPE_INCOMPATIBLE_WITH_Y_TYPE, "value", "start"), null) );
             return null;
         }
 
-        if (!val.getClass().isAssignableFrom(e.getClass())) {
-            // TODO here in the original code "interpreted" there was an error reporting utility.
+        if (!value.getClass().isAssignableFrom(end.getClass())) {
+            ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.X_TYPE_INCOMPATIBLE_WITH_Y_TYPE, "value", "end"), null) );
             return null;
         }
 
-        return gte(val, s) && lte(val, e);
+        return gte(value, start) && lte(value, end);
     }
 
     /**


### PR DESCRIPTION
down to 59 failed tests