### PR TITLE
DROOLS-1701 Fix closure context handling, misc fn issues

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledCustomFEELFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledCustomFEELFunction.java
@@ -18,6 +18,7 @@ package org.kie.dmn.feel.codegen.feel11;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -33,16 +34,30 @@ public class CompiledCustomFEELFunction extends BaseFEELFunction {
 
     private final List<String> parameters;
     private final Function<EvaluationContext, Object> body;
+    private final EvaluationContext ctx;
 
     public CompiledCustomFEELFunction(String name, List<String> parameters, Function<EvaluationContext, Object> body) {
+        this(name, parameters, body, null);
+    }
+
+    public CompiledCustomFEELFunction(String name, List<String> parameters, Function<EvaluationContext, Object> body, EvaluationContext ctx) {
         super( name );
         this.parameters = parameters;
         this.body = body;
+        this.ctx = ctx;
     }
 
     @Override
     public List<List<String>> getParameterNames() {
         return Arrays.asList( parameters );
+    }
+
+    public boolean isProperClosure() {
+        return ctx != null;
+    }
+
+    public EvaluationContext getEvaluationContext() {
+        return ctx;
     }
 
     @Override

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
@@ -107,6 +107,42 @@ public class CompiledFEELSemanticMappings {
         }
     }
     
+    public static <T> T coerceTo(Class<?> paramType, Object value) {
+        Object actual;
+        if( paramType.isAssignableFrom( value.getClass() ) ) {
+            actual = value;
+        } else {
+            // try to coerce
+            if( value instanceof Number ) {
+                if( paramType == byte.class || paramType == Byte.class ) {
+                    actual = ((Number)value).byteValue();
+                } else if( paramType == short.class || paramType == Short.class ) {
+                    actual = ((Number) value).shortValue();
+                } else if( paramType == int.class || paramType == Integer.class ) {
+                    actual = ((Number) value).intValue();
+                } else if( paramType == long.class || paramType == Long.class ) {
+                    actual = ((Number) value).longValue();
+                } else if( paramType == float.class || paramType == Float.class ) {
+                    actual = ((Number) value).floatValue();
+                } else if( paramType == double.class || paramType == Double.class ) {
+                    actual = ((Number) value).doubleValue();
+                } else {
+                    throw new IllegalArgumentException( "Unable to coerce parameter "+value+". Expected "+paramType+" but found "+value.getClass() );
+                }
+            } else if ( value instanceof String
+                    && ((String) value).length() == 1
+                    && (paramType == char.class || paramType == Character.class) ) {
+                actual = ((String) value).charAt(0);
+            } else if ( value instanceof Boolean && paramType == boolean.class ) {
+                // Because Boolean can be also null, boolean.class is not assignable from Boolean.class. So we must coerce this.
+                actual = value;
+            } else {
+                throw new IllegalArgumentException( "Unable to coerce parameter "+value+". Expected "+paramType+" but found "+value.getClass() );
+            }
+        }
+        return (T) actual;
+    }
+    
     /**
      * Represent a [e1, e2, e3] construct.
      */

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSupport.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSupport.java
@@ -376,19 +376,33 @@ public class CompiledFEELSupport {
             return null;
         }
         if (function instanceof FEELFunction) {
-            Object[] invocationParams = null;
-            if (params instanceof List) {
-                invocationParams = ((List) params).toArray(new Object[]{});
-            } else if (params instanceof Object[]) {
-                invocationParams = (Object[]) params;
-            } else {
-                invocationParams = new Object[]{params};
+            Object[] invocationParams = toFunctionParams(params);
+
+            FEELFunction f = (FEELFunction) function;
+
+            if (function instanceof CompiledCustomFEELFunction) {
+                CompiledCustomFEELFunction ff = (CompiledCustomFEELFunction) function;
+                if (ff.isProperClosure()) {
+                    return ff.invokeReflectively(ff.getEvaluationContext(), invocationParams);
+                }
             }
-            return ((FEELFunction) function).invokeReflectively(feelExprCtx, invocationParams);
+
+            return f.invokeReflectively(feelExprCtx, invocationParams);
         } else if (function instanceof UnaryTest) {
             throw new UnsupportedOperationException("TODO"); // TODO
         }
         return null;
     }
 
+    private static Object[] toFunctionParams(Object params) {
+        Object[] invocationParams = null;
+        if (params instanceof List) {
+            invocationParams = ((List) params).toArray(new Object[]{});
+        } else if (params instanceof Object[]) {
+            invocationParams = (Object[]) params;
+        } else {
+            invocationParams = new Object[]{params};
+        }
+        return invocationParams;
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/EvaluationContext.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/EvaluationContext.java
@@ -30,6 +30,8 @@ public interface EvaluationContext {
 
     void exitFrame();
 
+    EvaluationContext current();
+
     void setValue(String name, Object value );
 
     Object getValue(String name );

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FunctionDefs.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FunctionDefs.java
@@ -1,0 +1,70 @@
+package org.kie.dmn.feel.lang;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.drools.javaparser.JavaParser;
+import org.drools.javaparser.ast.NodeList;
+import org.drools.javaparser.ast.expr.CastExpr;
+import org.drools.javaparser.ast.expr.ClassExpr;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.javaparser.ast.expr.NameExpr;
+import org.drools.javaparser.ast.expr.NullLiteralExpr;
+import org.drools.javaparser.ast.expr.StringLiteralExpr;
+import org.drools.javaparser.ast.type.Type;
+import org.kie.dmn.feel.lang.ast.FunctionDefNode;
+
+public class FunctionDefs {
+
+    public static Expression asMethodCall(
+            String className,
+            String methodSignature,
+            List<String> params) {
+        // creating a simple algorithm to find the method in java
+        // without using any external libraries in this initial implementation
+        // might need to explicitly use a classloader here
+        String[] mp = FunctionDefNode.parseMethod(methodSignature);
+        try {
+            String methodName = mp[0];
+            String[] paramTypeNames = FunctionDefNode.parseParams(mp[1]);
+            ArrayList<Expression> paramExprs = new ArrayList<>();
+            if (paramTypeNames.length == params.size()) {
+                for (int i = 0; i < params.size(); i++) {
+                    String paramName = params.get(i);
+                    String paramTypeName = paramTypeNames[i];
+                    Type paramTypeCanonicalName =
+                            JavaParser.parseType(
+                                    FunctionDefNode.getType(paramTypeName).getCanonicalName());
+
+                    Expression param =
+                        new CastExpr(paramTypeCanonicalName,
+                            new MethodCallExpr(
+                                null,
+                                "coerceTo",
+                                new NodeList<>(
+                                        new ClassExpr(paramTypeCanonicalName),
+                                        new MethodCallExpr(
+                                            new NameExpr("feelExprCtx"),
+                                            "getValue",
+                                            new NodeList<>(new StringLiteralExpr(paramName))
+                                        ))));
+
+                    paramExprs.add(param);
+                }
+
+                return new MethodCallExpr(
+                        new NameExpr(className),
+                        methodName,
+                        new NodeList<>(paramExprs));
+            } else {
+                return new NullLiteralExpr();
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionDefNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionDefNode.java
@@ -37,8 +37,8 @@ public class FunctionDefNode
         extends BaseNode {
 
     private static final String ANONYMOUS = "<anonymous>";
-    private final Pattern METHOD_PARSER = Pattern.compile( "(.+)\\((.*)\\)" );
-    private final Pattern PARAMETER_PARSER = Pattern.compile( "([^, ]+)" );
+    private static final Pattern METHOD_PARSER = Pattern.compile( "(.+)\\((.*)\\)" );
+    private static final Pattern PARAMETER_PARSER = Pattern.compile( "([^, ]+)" );
 
 
     private List<NameDefNode> formalParameters;
@@ -128,7 +128,7 @@ public class FunctionDefNode
         }
     }
 
-    private Class<?> getType(String typeName)
+    public static Class<?> getType(String typeName)
             throws ClassNotFoundException {
         // first check if it is primitive
         Class<?> type = convertPrimitiveNameToType( typeName );
@@ -140,7 +140,7 @@ public class FunctionDefNode
         return type;
     }
 
-    public String[] parseMethod(String signature ) {
+    public static String[] parseMethod(String signature ) {
         Matcher m = METHOD_PARSER.matcher( signature );
         if( m.matches() ) {
             String[] result = new String[2];
@@ -152,7 +152,7 @@ public class FunctionDefNode
     }
 
 
-    public String[] parseParams(String params) {
+    public static String[] parseParams(String params) {
         List<String> ps = new ArrayList<>(  );
         if( params.trim().length() > 0 ) {
             Matcher m = PARAMETER_PARSER.matcher( params.trim() );
@@ -163,7 +163,7 @@ public class FunctionDefNode
         return ps.toArray( new String[ps.size()] );
     }
 
-    public static Class<?> convertPrimitiveNameToType( String typeName ) {
+    private static Class<?> convertPrimitiveNameToType( String typeName ) {
         if (typeName.equals( "int" )) {
             return int.class;
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
@@ -38,10 +38,14 @@ public class EvaluationContextImpl implements EvaluationContext {
     private boolean performRuntimeTypeCheck = false;
     private ClassLoader rootClassLoader;
 
-    public EvaluationContextImpl(ClassLoader cl, FEELEventListenersManager eventsManager) {
+    private EvaluationContextImpl(ClassLoader cl, FEELEventListenersManager eventsManager, Deque<ExecutionFrame> stack) {
         this.eventsManager = eventsManager;
         this.rootClassLoader = cl;
-        this.stack = new ArrayDeque<>();
+        this.stack = new ArrayDeque<>(stack);
+    }
+
+    public EvaluationContextImpl(ClassLoader cl, FEELEventListenersManager eventsManager) {
+        this(cl, eventsManager, new ArrayDeque<>());
         // we create a rootFrame to hold all the built in functions
         push( RootExecutionFrame.INSTANCE );
         // and then create a global frame to be the starting frame
@@ -53,6 +57,11 @@ public class EvaluationContextImpl implements EvaluationContext {
     public EvaluationContextImpl(FEELEventListenersManager eventsManager, DMNRuntime dmnRuntime) {
         this(dmnRuntime.getRootClassLoader(), eventsManager);
         this.dmnRuntime = dmnRuntime;
+    }
+
+    @Override
+    public EvaluationContext current() {
+        return new EvaluationContextImpl(rootClassLoader, eventsManager, new ArrayDeque<>(stack));
     }
 
     public void push(ExecutionFrame obj) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/SilentWrappingEvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/SilentWrappingEvaluationContextImpl.java
@@ -51,6 +51,11 @@ public class SilentWrappingEvaluationContextImpl implements EvaluationContext {
     }
 
     @Override
+    public EvaluationContext current() {
+        return new SilentWrappingEvaluationContextImpl(wrapped.current());
+    }
+
+    @Override
     public void setValue(String name, Object value) {
         wrapped.setValue(name, value);
     }


### PR DESCRIPTION
This has mostly to do with how Functions (or, to be more correct, _closures_) are generated.
Closures should have a reference to their enclosing environment, thereby letting you referring to a sibling, unqualified. E.g., this is allowed

```js
{ 
  blah: function() "hi",
  blip: function(e) hi() + e
}
```
This PR also add support to "external" functions, with correct type coercion.

Some tests still fail, but they are mostly related with erroneous situations: in fact, the errors are mostly related to the fact that the code **does not compile** or it compiles to a **return null** but we are expected to emit an error as well.

We are down to 47 errors (were: 59) -- yay


