### PR TITLE
DROOLS-1701 unary not expression

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSupport.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSupport.java
@@ -399,7 +399,7 @@ public class CompiledFEELSupport {
 
             return f.invokeReflectively(feelExprCtx, invocationParams);
         } else if (function instanceof UnaryTest) {
-            throw new UnsupportedOperationException("TODO"); // TODO
+            return ((UnaryTest) function).apply(feelExprCtx, params);
         }
         return null;
     }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerResult.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerResult.java
@@ -16,8 +16,10 @@
 
 package org.kie.dmn.feel.codegen.feel11;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.drools.javaparser.ast.body.FieldDeclaration;
@@ -70,13 +72,17 @@ public class DirectCompilerResult {
     public boolean addFieldDesclaration(FieldDeclaration d) {
         return fieldDeclarations.add(d);
     }
-    
-    public static Set<FieldDeclaration> mergeFDs( DirectCompilerResult... sets ) {
+
+    public static Set<FieldDeclaration> mergeFDs( List<DirectCompilerResult> sets ) {
         Set<FieldDeclaration> result = new HashSet<>();
         for ( DirectCompilerResult fs : sets ) {
             result.addAll(fs.getFieldDeclarations());
         }
         return result;
+    }
+    
+    public static Set<FieldDeclaration> mergeFDs( DirectCompilerResult... sets ) {
+        return mergeFDs(Arrays.asList(sets));
     }
 
     public Expression getExpression() {


### PR DESCRIPTION
brings failed to tests down to 7 (!!)

but it currently breaks the cases `not(true)` and `not(false)` which we should discuss further 